### PR TITLE
format for private.txt PyPi packages should be package==0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Version 1.0.4 (2022-12-23)
+
+* bug fix: format for private.txt PyPi packages should be package==0.0.0
+
+## Version 1.0.2 (2022-??-??)
+
+Refactor set-output. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+
 ## Version 1.0.1 (2022-10-12)
 
 Add PyPi package support.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 
       # THIS ACTION WITH A GITHUB REPOSITORY:
       - name: Add the edx-ora2 XBlock
-        uses: openedx-actions/tutor-plugin-build-openedx-add-requirement@v1.0.1
+        uses: openedx-actions/tutor-plugin-build-openedx-add-requirement@v1.0.4
         with:
           repository: edx-ora2
           repository-organization: openedx

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       if: inputs.pip-package != ''
       shell: bash
       run: |-
-        echo "${{ inputs.pip-package }}${{ inputs.pip-package-version }}" >> ${PLUGINS_PATH}/private.txt
+        echo "${{ inputs.pip-package }}==${{ inputs.pip-package-version }}" >> ${PLUGINS_PATH}/private.txt
         echo "new PyPi requirement added to private.txt: "
 
     - name: Add editable requirement to private.txt


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ * ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- format for private.txt PyPi packages should be package==0.0.0
